### PR TITLE
Fixed RGBA convert issue (missing img.filename)

### DIFF
--- a/imghide.py
+++ b/imghide.py
@@ -50,6 +50,7 @@ def convertToRGB(img):
 		rgba_image.load()
 		background = Image.new("RGB", rgba_image.size, (255, 255, 255))
 		background.paste(rgba_image, mask = rgba_image.split()[3])
+		background.filename = img.filename
 		print("[yellow]Converted image to RGB [/yellow]")
 		return background
 	except Exception as e:


### PR DESCRIPTION
Bug fixed:

Image Mode: RGBA
Converted image to RGB 
Traceback (most recent call last):
  File "/Users/r/Downloads/imghide.py", line 334, in <module>
    main()
  File "/Users/r/Downloads/imghide.py", line 266, in main
    encodeImage(image=newimg,message=cipher,filename=image.filename)
                                                     ^^^^^^^^^^^^^^
AttributeError: 'Image' object has no attribute 'filename'